### PR TITLE
Genome assemblies

### DIFF
--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/refgenome/GenomeAssembliesSerializerTest.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/refgenome/GenomeAssembliesSerializerTest.java
@@ -19,7 +19,7 @@ public class GenomeAssembliesSerializerTest {
 
     private static GenomeAssemblies fakeUpGenomeAssemblies() {
         GenomeAssemblies assemblies = new GenomeAssemblies();
-        assemblies.putAssembly(GenomeAssembly.NCBI_36, Paths.get("/path/to/ncbi36.fa")); // hg18
+        assemblies.putAssembly(GenomeAssembly.GRCH_38, Paths.get("/path/to/grch38.fa")); // hg38
         assemblies.putAssembly(GenomeAssembly.GRCH_37, Paths.get("/path/to/grch37.fa")); // hg19
         return assemblies;
     }
@@ -27,7 +27,7 @@ public class GenomeAssembliesSerializerTest {
 
     private static Properties fakeUpProperties() {
         Properties properties = new Properties();
-        properties.put("NCBI_36.fasta.path", "/path/to/ncbi36.fa");
+        properties.put("GRCH_38.fasta.path", "/path/to/grch38.fa");
         properties.put("GRCH_37.fasta.path", "/path/to/grch37.fa");
 
         return properties;
@@ -42,7 +42,7 @@ public class GenomeAssembliesSerializerTest {
         GenomeAssemblies assemblies = GenomeAssembliesSerializer.deserialize(is);
 
         assertThat(assemblies.getAssemblyMap().size(), is(2));
-        assertThat(assemblies.getAssemblyMap().get(GenomeAssembly.NCBI_36).toFile().getName(), is("ncbi36.fa"));
+        assertThat(assemblies.getAssemblyMap().get(GenomeAssembly.GRCH_38).toFile().getName(), is("grch38.fa"));
         assertThat(assemblies.getAssemblyMap().get(GenomeAssembly.HG_19).toFile().getName(), is("grch37.fa"));
     }
 
@@ -56,8 +56,8 @@ public class GenomeAssembliesSerializerTest {
         Properties properties = new Properties();
         properties.load(is);
 
-        assertTrue(properties.containsKey("NCBI_36.fasta.path"));
-        assertThat(properties.getProperty("NCBI_36.fasta.path"), is("/path/to/ncbi36.fa"));
+        assertTrue(properties.containsKey("GRCH_38.fasta.path"));
+        assertThat(properties.getProperty("GRCH_38.fasta.path"), is("/path/to/grch38.fa"));
 
         assertTrue(properties.containsKey("GRCH_37.fasta.path"));
         assertThat(properties.getProperty("GRCH_37.fasta.path"), is("/path/to/grch37.fa"));

--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidatorTest.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidatorTest.java
@@ -72,12 +72,12 @@ public class GenomicPositionValidatorTest {
 
     @Test
     public void variantWithUnknownGenomeAssembly() throws Exception {
-        Mockito.when(assemblies.hasFastaForAssembly(GenomeAssembly.HG_18))
+        Mockito.when(assemblies.hasFastaForAssembly(GenomeAssembly.HG_38))
                 .thenReturn(false);
 
         Variant variant = Variant.newBuilder()
                 .setVariantPosition(VariantPosition.newBuilder()
-                        .setGenomeAssembly(GenomeAssembly.HG_18)
+                        .setGenomeAssembly(GenomeAssembly.HG_38)
                         .setContig("chr1")
                         .setPos(1234)
                         .setRefAllele("C")
@@ -87,7 +87,7 @@ public class GenomicPositionValidatorTest {
 
         final List<ValidationResult> results = validator.validate(variant);
         assertThat(results.size(), is(1));
-        assertThat(results, hasItem(ValidationResult.fail("Fasta file for genome assembly NCBI_36 is not present")));
+        assertThat(results, hasItem(ValidationResult.fail("Fasta file for genome assembly GRCH_38 is not present")));
     }
 
     @Test

--- a/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/DiseaseCaseDataController.java
+++ b/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/DiseaseCaseDataController.java
@@ -284,6 +284,10 @@ public final class DiseaseCaseDataController extends AbstractDiseaseCaseDataCont
                     .setVariantValidation(VariantValidation.newBuilder()
                             .setContext(ctx)
                             .build())
+                    .setVariantPosition(VariantPosition.newBuilder()
+                            // we want all variants to have GRCH37 assembly by default
+                            .setGenomeAssembly(GenomeAssembly.GRCH_37)
+                            .build())
                     .build();
 
             try {

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/GuiElementValuesTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/GuiElementValuesTest.java
@@ -26,8 +26,8 @@ public class GuiElementValuesTest {
         // instance is loaded in setUp method
 
         // assert
-        assertThat(instance.getGenomeBuild().size(), is(4));
-        assertThat(instance.getGenomeBuild(), hasItems(GenomeAssembly.GRCH_37, GenomeAssembly.GRCH_38, GenomeAssembly.NCBI_36, GenomeAssembly.UNKNOWN_GENOME_ASSEMBLY));
+        assertThat(instance.getGenomeBuild().size(), is(3));
+        assertThat(instance.getGenomeBuild(), hasItems(GenomeAssembly.GRCH_37, GenomeAssembly.GRCH_38, GenomeAssembly.UNKNOWN_GENOME_ASSEMBLY));
 
         assertThat(instance.getChromosome().size(), is(4));
         assertThat(instance.getChromosome(), hasItems("1", "4", "5", "X"));
@@ -66,7 +66,7 @@ public class GuiElementValuesTest {
 
     @Test
     public void toStringIsTested() {
-        String expected = "GuiElementValues{genomeBuild=[UNKNOWN_GENOME_ASSEMBLY, NCBI_36, GRCH_38, GRCH_37], chromosome=[1, 4, 5, X], " +
+        String expected = "GuiElementValues{genomeBuild=[UNKNOWN_GENOME_ASSEMBLY, GRCH_38, GRCH_37], chromosome=[1, 4, 5, X], " +
                 "variantClass=[coding, enhancer, promoter], pathomechanism=[unknown, coding|missense, coding|stop-codon], " +
                 "consequence=[Exon skipping, Intron retention], reporter=[no, up, down], " +
                 "emsa=[yes, no], otherChoices=[no], otherEffect=[Telomerase, Nonspecific_EMSA], " +

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/MendelianVariantControllerTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/MendelianVariantControllerTest.java
@@ -107,7 +107,7 @@ public class MendelianVariantControllerTest extends ApplicationTest {
         // assert
         Variant variant = controller.getData();
         final VariantPosition vp = variant.getVariantPosition();
-        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.NCBI_36));
+        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.GRCH_38));
         assertThat(vp.getContig(), is("1"));
         assertThat(vp.getPos(), is(12345345));
         assertThat(vp.getRefAllele(), is("C"));
@@ -148,7 +148,7 @@ public class MendelianVariantControllerTest extends ApplicationTest {
         Variant variant = controller.getData();
         VariantPosition vp = variant.getVariantPosition();
         // assert
-        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.NCBI_36));
+        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.GRCH_38));
         assertThat(vp.getContig(), is("1"));
         assertThat(vp.getPos(), is(12345345));
         assertThat(vp.getRefAllele(), is("C"));

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/SomaticVariantControllerTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/SomaticVariantControllerTest.java
@@ -107,7 +107,7 @@ public class SomaticVariantControllerTest extends ApplicationTest {
         // assert
         Variant variant = controller.getData();
         VariantPosition variantPosition = variant.getVariantPosition();
-        assertThat(variantPosition.getGenomeAssembly(), is(GenomeAssembly.NCBI_36));
+        assertThat(variantPosition.getGenomeAssembly(), is(GenomeAssembly.GRCH_38));
         assertThat(variantPosition.getContig(), is("1"));
         assertThat(variantPosition.getPos(), is(12345345));
         assertThat(variantPosition.getRefAllele(), is("C"));

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/SplicingVariantControllerTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/SplicingVariantControllerTest.java
@@ -36,14 +36,14 @@ public class SplicingVariantControllerTest extends ApplicationTest {
     public static void setUpBefore() throws Exception {
         // for headless GUI testing, set the "not.headless" system property to true or comment out if you want to see the
         // robot in action
-        if (!Boolean.getBoolean("not.headless")) {
-            System.setProperty("testfx.robot", "glass");
-            System.setProperty("testfx.headless", "true");
-            System.setProperty("prism.order", "sw");
-            System.setProperty("prism.text", "t2k");
-            System.setProperty("java.awt.headless", "true");
-            System.setProperty("headless.geometry", "1200x760-32");
-        }
+//        if (!Boolean.getBoolean("not.headless")) {
+//            System.setProperty("testfx.robot", "glass");
+//            System.setProperty("testfx.headless", "true");
+//            System.setProperty("prism.order", "sw");
+//            System.setProperty("prism.text", "t2k");
+//            System.setProperty("java.awt.headless", "true");
+//            System.setProperty("headless.geometry", "1200x760-32");
+//        }
     }
 
     /**
@@ -95,7 +95,7 @@ public class SplicingVariantControllerTest extends ApplicationTest {
         // assert
         Variant variant = controller.getData();
         final VariantPosition vp = variant.getVariantPosition();
-        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.NCBI_36));
+        assertThat(vp.getGenomeAssembly(), is(GenomeAssembly.GRCH_38));
         assertThat(vp.getContig(), is("1"));
         assertThat(vp.getPos(), is(12));
         assertThat(vp.getRefAllele(), is("C"));

--- a/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/Codecs.java
+++ b/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/Codecs.java
@@ -360,9 +360,6 @@ public class Codecs {
             case "grch38":
             case "hg38":
                 return GenomeAssembly.GRCH_38;
-            case "hg18":
-            case "ncbi36":
-                return GenomeAssembly.NCBI_36;
             default:
                 return GenomeAssembly.UNKNOWN_GENOME_ASSEMBLY;
         }

--- a/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/io/PhenoPacketCodec.java
+++ b/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/io/PhenoPacketCodec.java
@@ -226,8 +226,6 @@ public class PhenoPacketCodec {
 
         private static String hcaGenomeAssemblyToPhenoPacketGenomeAssembly(org.monarchinitiative.hpo_case_annotator.model.proto.GenomeAssembly genomeAssembly) {
             switch (genomeAssembly) {
-                case NCBI_36:
-                    return GenomeAssembly.NCBI_36.name();
                 case GRCH_37:
                     return GenomeAssembly.GRCH_37.name();
                 case GRCH_38:

--- a/hpo-case-annotator-model/src/main/proto/org/monarchinitiative/hpo-case-annotator/model/model.proto
+++ b/hpo-case-annotator-model/src/main/proto/org/monarchinitiative/hpo-case-annotator/model/model.proto
@@ -33,8 +33,9 @@ enum GenomeAssembly {
 
     UNKNOWN_GENOME_ASSEMBLY = 0;
 
-    NCBI_36 = 1;
-    HG_18 = 1;
+//    Commenting out only and not deleting so that we know that it was here
+//    NCBI_36 = 1;
+//    HG_18 = 1;
 
     GRCH_38 = 2;
     HG_38 = 2;


### PR DESCRIPTION
Clean up genome assemblies:
- remove obsolete NCBI36
- select HG19 by default for newly created variants