### PR TITLE
Add IMPRECISE flag to CNV variants

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -7,5 +7,4 @@ Issues to be solved in *Hpo Case Annotator* gui
 - one variant can lead to utilization of multiple CS sites
 - add `Help | About` dialog to show a version of the GUI
 
-- use 1-based coordinates in structural variants
 - structural variant validators

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,3 +6,7 @@ Issues to be solved in *Hpo Case Annotator* gui
 - one variant can have more than single consequence
 - one variant can lead to utilization of multiple CS sites
 - add `Help | About` dialog to show a version of the GUI
+
+- add `imprecise` checkbox
+- use 1-based coordinates in structural variants
+- structural variant validators

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -7,6 +7,5 @@ Issues to be solved in *Hpo Case Annotator* gui
 - one variant can lead to utilization of multiple CS sites
 - add `Help | About` dialog to show a version of the GUI
 
-- add `imprecise` checkbox
 - use 1-based coordinates in structural variants
 - structural variant validators

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,5 +6,3 @@ Issues to be solved in *Hpo Case Annotator* gui
 - one variant can have more than single consequence
 - one variant can lead to utilization of multiple CS sites
 - add `Help | About` dialog to show a version of the GUI
-
-- structural variant validators

--- a/hpo-case-annotator-core/src/main/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidator.java
+++ b/hpo-case-annotator-core/src/main/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidator.java
@@ -24,7 +24,6 @@ public final class GenomicPositionValidator implements Validator<Variant> {
 
     GenomicPositionValidator(GenomeAssemblies genomeAssemblies) {
         this.genomeAssemblies = genomeAssemblies;
-
     }
 
     /**
@@ -89,6 +88,11 @@ public final class GenomicPositionValidator implements Validator<Variant> {
     public List<ValidationResult> validate(Variant variant) {
         List<ValidationResult> results = new ArrayList<>();
 
+        if (variant.getVariantClass().equals("structural")) {
+            // we do not validate genomic position of structural variants, since we do not enter
+            // ref, alt, and snippet
+            return results;
+        }
         GenomeAssembly assembly = variant.getVariantPosition().getGenomeAssembly();
 
         if (!genomeAssemblies.hasFastaForAssembly(assembly)) { // no validation is possible if the fasta file is not present

--- a/hpo-case-annotator-core/src/main/java/org/monarchinitiative/hpo_case_annotator/core/validation/VariantValidationDataSyntaxValidator.java
+++ b/hpo-case-annotator-core/src/main/java/org/monarchinitiative/hpo_case_annotator/core/validation/VariantValidationDataSyntaxValidator.java
@@ -31,6 +31,10 @@ public class VariantValidationDataSyntaxValidator implements Validator<VariantVa
             case SPLICING:
                 results.addAll(validateSplicingFields(instance));
                 break;
+            case CNV:
+            case BKPT:
+                results.addAll(validateStructuralFields(instance));
+                break;
             default:
                 results.add(ValidationResult.fail("Unknown variant validation context " + context));
                 break;
@@ -63,6 +67,10 @@ public class VariantValidationDataSyntaxValidator implements Validator<VariantVa
 
     private Collection<? extends ValidationResult> validateMendelianFields(VariantValidation instance) {
         // TODO - validate data in the mendelian validation
+        return Collections.emptyList();
+    }
+
+    private Collection<? extends ValidationResult> validateStructuralFields(VariantValidation instance) {
         return Collections.emptyList();
     }
 }

--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/DiseaseCaseModelExample.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/DiseaseCaseModelExample.java
@@ -8,7 +8,7 @@ import org.monarchinitiative.hpo_case_annotator.model.proto.*;
 public class DiseaseCaseModelExample {
 
     // TODO - add other models for testing here
-
+    static final String SOFTWARE_VERSION = "Hpo Case Annotator";
 
     public static DiseaseCase benMahmoud2013B3GLCT() {
         return DiseaseCase.newBuilder()
@@ -71,6 +71,96 @@ public class DiseaseCaseModelExample {
                 .setBiocurator(Biocurator.newBuilder()
                         .setBiocuratorId("HPO:ahegde")
                         .build())
+                .setSoftwareVersion(SOFTWARE_VERSION)
+                .build();
+    }
+
+    /**
+     * @return {@link DiseaseCase} representing a heterozygous single exon deletion causing TCS1 (autosomal dominant
+     * disorder).
+     */
+    public static DiseaseCase structural_beygo_2012_TCOF1_M18662() {
+        /* Genome build */
+        return DiseaseCase.newBuilder()
+
+                /* Publication data */
+                .setPublication(
+                        Publication.newBuilder().setAuthorList("Beygo J, Buiting K, Seland S, Lüdecke HJ, Hehr U, Lich C, Prager B, Lohmann DR, Wieczorek D")
+                                .setTitle("First Report of a Single Exon Deletion in TCOF1 Causing Treacher Collins Syndrome")
+                                .setJournal("Mol Syndromol")
+                                .setYear("2012")
+                                .setVolume("2(2)")
+                                .setPages("53-59")
+                                .setPmid("22712005")
+                                .build())
+                .setMetadata("Authors describe a proband M18662 with presence of TCS1")
+                .setGene(Gene.newBuilder()
+                        .setSymbol("TCOF1")
+                        .setEntrezId(6949)
+                        .build())
+                /* Variants which belong to this model */
+                .addVariant(exampleStructuralVariant())
+                /* Family/proband information */
+                .setFamilyInfo(FamilyInfo.newBuilder()
+                        .setFamilyOrProbandId("M18662")
+                        .setSex(Sex.FEMALE)
+                        .setAge("P26Y")
+                        .build())
+                /* HPO terms */
+                .addPhenotype(OntologyClass.newBuilder()
+                        .setId("HP:0011453")
+                        .setLabel("Abnormality of the incus")
+                        .setNotObserved(false)
+                        .build())
+                .addPhenotype(OntologyClass.newBuilder()
+                        .setId("HP:0000405")
+                        .setLabel("Conductive hearing impairment")
+                        .setNotObserved(false)
+                        .build())
+                .addPhenotype(OntologyClass.newBuilder()
+                        .setId("HP:0025336")
+                        .setLabel("Delayed ability to sit")
+                        .setNotObserved(true)
+                        .build())
+                .addPhenotype(OntologyClass.newBuilder()
+                        .setId("HP:0000750")
+                        .setLabel("Delayed speech and language development")
+                        .setNotObserved(true)
+                        .build())
+                .setDisease(Disease.newBuilder()
+                        .setDatabase("OMIM")
+                        .setDiseaseId("154500")
+                        .setDiseaseName("TREACHER COLLINS SYNDROME 1; TCS1")
+                        .build())
+                /* Biocurator */
+                .setBiocurator(Biocurator.newBuilder()
+                        .setBiocuratorId("HPO:walterwhite")
+                        .build())
+                .setSoftwareVersion(SOFTWARE_VERSION)
+                .build();
+    }
+
+    public static Variant exampleStructuralVariant() {
+        return Variant.newBuilder()
+                .setVariantPosition(VariantPosition.newBuilder()
+                        .setGenomeAssembly(GenomeAssembly.GRCH_37)
+                        .setContig("5")
+                        .setPos(149741531)
+                        .setPos2(149744897)
+                        .setRefAllele("N")
+                        .setAltAllele("<DEL>")
+                        .setCiBeginOne(-5)
+                        .setCiBeginTwo(5)
+                        .setCiEndOne(-15)
+                        .setCiEndTwo(10)
+                        .build())
+                .setVariantClass("structural")
+                .setSvType(StructuralType.DEL)
+                .setGenotype(Genotype.HETEROZYGOUS)
+                .setVariantValidation(VariantValidation.newBuilder()
+                        .setContext(VariantValidation.Context.CNV)
+                        .build())
+                .setImprecise(true)
                 .build();
     }
 
@@ -122,4 +212,6 @@ public class DiseaseCaseModelExample {
                         .build())
                 .build();
     }
+
+
 }

--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidatorTest.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/GenomicPositionValidatorTest.java
@@ -17,6 +17,7 @@ import org.monarchinitiative.hpo_case_annotator.model.proto.Variant;
 import org.monarchinitiative.hpo_case_annotator.model.proto.VariantPosition;
 
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -228,6 +229,17 @@ public class GenomicPositionValidatorTest {
         final List<ValidationResult> results = validator.validate(variant);
         assertThat(results.size(), is(1));
         assertThat(results, hasItem(ValidationResult.fail("Ref sequence 'G' does not match the sequence 'A' observed at 'chr7:10489-10490'")));
+    }
+
+
+    @Test
+    public void validateStructuralVariant() {
+        // this validator does not validate structural variants, since they do not contain neither ref, alt, nor snippet
+        List<ValidationResult> results = validator.validate(Variant.newBuilder()
+                .setVariantClass("structural")
+                .build());
+
+        assertThat(results, is(Collections.emptyList()));
     }
 
     /**

--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/ValidationRunnerTest.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/ValidationRunnerTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.monarchinitiative.hpo_case_annotator.core.DiseaseCaseModelExample;
@@ -17,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class ValidationRunnerTest {
 
@@ -46,10 +46,10 @@ public class ValidationRunnerTest {
      */
     @Test
     public void validateSingleModel() throws Exception {
-        Mockito.when(assemblies.hasFastaForAssembly(GenomeAssembly.GRCH_37)).thenReturn(true);
-        Mockito.when(assemblies.getSequenceDaoForAssembly(GenomeAssembly.GRCH_37)).thenReturn(Optional.of(hg19SequenceDao));
-        Mockito.when(hg19SequenceDao.fetchSequence("13", 31843348, 31843349)).thenReturn("A"); // expectedRefAllele
-        Mockito.when(hg19SequenceDao.fetchSequence("13", 31843343, 31843354)).thenReturn("TTTCTAGGCTT"); // 0-based numbering for both begin and end coordinates
+        when(assemblies.hasFastaForAssembly(GenomeAssembly.GRCH_37)).thenReturn(true);
+        when(assemblies.getSequenceDaoForAssembly(GenomeAssembly.GRCH_37)).thenReturn(Optional.of(hg19SequenceDao));
+        when(hg19SequenceDao.fetchSequence("13", 31843348, 31843349)).thenReturn("A"); // expectedRefAllele
+        when(hg19SequenceDao.fetchSequence("13", 31843343, 31843354)).thenReturn("TTTCTAGGCTT"); // 0-based numbering for both begin and end coordinates
 
         final DiseaseCase diseaseCase = DiseaseCaseModelExample.benMahmoud2013B3GLCT();
 
@@ -57,6 +57,21 @@ public class ValidationRunnerTest {
 
         // model valid, no failures are produced
         assertTrue(results.isEmpty());
+    }
+
+    @Test
+    public void validateModelWithStructuralVariant() {
+        when(assemblies.hasFastaForAssembly(GenomeAssembly.GRCH_37)).thenReturn(true);
+        when(assemblies.getSequenceDaoForAssembly(GenomeAssembly.GRCH_37)).thenReturn(Optional.of(hg19SequenceDao));
+
+        when(hg19SequenceDao.fetchSequence("13", 31843348, 31843349)).thenReturn("A"); // expectedRefAllele
+        when(hg19SequenceDao.fetchSequence("13", 31843343, 31843354)).thenReturn("TTTCTAGGCTT"); // 0-based numbering for both begin and end coordinates
+
+        DiseaseCase diseaseCase = DiseaseCaseModelExample.structural_beygo_2012_TCOF1_M18662();
+
+        List<ValidationResult> results = runner.validateSingleModel(diseaseCase);
+
+        System.out.println(results);
     }
 
     @Test

--- a/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/VariantSyntaxValidatorTest.java
+++ b/hpo-case-annotator-core/src/test/java/org/monarchinitiative/hpo_case_annotator/core/validation/VariantSyntaxValidatorTest.java
@@ -2,6 +2,7 @@ package org.monarchinitiative.hpo_case_annotator.core.validation;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.monarchinitiative.hpo_case_annotator.core.DiseaseCaseModelExample;
 import org.monarchinitiative.hpo_case_annotator.model.proto.GenomeAssembly;
 import org.monarchinitiative.hpo_case_annotator.model.proto.Variant;
 import org.monarchinitiative.hpo_case_annotator.model.proto.VariantPosition;
@@ -9,6 +10,7 @@ import org.monarchinitiative.hpo_case_annotator.model.proto.VariantPosition;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class VariantSyntaxValidatorTest {
@@ -142,5 +144,12 @@ public class VariantSyntaxValidatorTest {
         assertThat(results, hasItem(ValidationResult.fail("Invalid snippet format: INVALID[X/Z]SNIPPET")));
     }
 
+    @Test
+    public void structuralVariant() {
+        Variant variant = DiseaseCaseModelExample.exampleStructuralVariant();
 
+        List<ValidationResult> results = validator.validate(variant);
+
+        assertThat(results.size(), is(0));
+    }
 }

--- a/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/BreakpointVariantController.java
+++ b/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/BreakpointVariantController.java
@@ -19,7 +19,7 @@ import static org.monarchinitiative.hpo_case_annotator.core.validation.VariantSy
 import static org.monarchinitiative.hpo_case_annotator.core.validation.VariantSyntaxValidator.POSITIVE_INTEGER_REGEXP;
 
 /**
- *
+ * !!WARNING - not yet implemented!!
  */
 public final class BreakpointVariantController extends AbstractVariantController {
 

--- a/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantController.java
+++ b/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantController.java
@@ -64,6 +64,9 @@ public final class CnvVariantController extends AbstractVariantController {
     @FXML
     public CheckBox cosegregationCheckBox;
 
+    @FXML
+    public CheckBox impreciseCheckBox;
+
     private final String defaultRefAllele = "N";
 
     @Inject
@@ -119,6 +122,7 @@ public final class CnvVariantController extends AbstractVariantController {
 
         VariantValidation vv = variant.getVariantValidation();
         cosegregationCheckBox.setSelected(vv.getCosegregation());
+        impreciseCheckBox.setSelected(variant.getImprecise());
     }
 
     @Override
@@ -146,6 +150,7 @@ public final class CnvVariantController extends AbstractVariantController {
                         .setContext(VariantValidation.Context.CNV)
                         .setCosegregation(cosegregationCheckBox.isSelected())
                         .build())
+                .setImprecise(impreciseCheckBox.isSelected())
                 .build();
     }
 

--- a/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantController.java
+++ b/hpo-case-annotator-gui/src/main/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantController.java
@@ -34,9 +34,15 @@ public final class CnvVariantController extends AbstractVariantController {
     @FXML
     public ComboBox<String> chromosomeComboBox;
 
+    /**
+     * Text field for 1-based begin position of the Cnv
+     */
     @FXML
     public TextField beginTextField;
 
+    /**
+     * Text field for 1-based end position of the Cnv
+     */
     @FXML
     public TextField endTextField;
 
@@ -109,7 +115,7 @@ public final class CnvVariantController extends AbstractVariantController {
         VariantPosition vp = variant.getVariantPosition();
         genomeBuildComboBox.setValue(vp.getGenomeAssembly());
         chromosomeComboBox.setValue(vp.getContig());
-        beginTextField.setText(String.valueOf(vp.getPos() - 1)); // convert to 0-based
+        beginTextField.setText(String.valueOf(vp.getPos()));
         endTextField.setText(String.valueOf(vp.getPos2()));
         ciBeginFirstTextField.setText(String.valueOf(vp.getCiBeginOne()));
         ciBeginSecondTextField.setText(String.valueOf(vp.getCiBeginTwo()));
@@ -132,9 +138,8 @@ public final class CnvVariantController extends AbstractVariantController {
                 .setVariantPosition(VariantPosition.newBuilder()
                         .setGenomeAssembly(genomeBuildComboBox.getValue() == null ? GenomeAssembly.UNKNOWN_GENOME_ASSEMBLY : genomeBuildComboBox.getValue())
                         .setContig(chromosomeComboBox.getValue() == null ? "NA" : chromosomeComboBox.getValue())
-                        // we need to save 1-based coordinate in the VariantPosition, hence +1
-                        .setPos(parseIntOrGetDefaultValue(beginTextField::getText, 0) + 1) // convert to 1-based
-                        .setPos2(parseIntOrGetDefaultValue(endTextField::getText, 0))
+                        .setPos(parseIntOrGetDefaultValue(beginTextField::getText, 0)) // begin is 1-based
+                        .setPos2(parseIntOrGetDefaultValue(endTextField::getText, 0)) // end is also 1-based
                         .setRefAllele(defaultRefAllele)
                         .setAltAllele(String.format("<%s>", svType.name()))
                         .setCiBeginOne(parseIntOrGetDefaultValue(ciBeginFirstTextField::getText, 0))
@@ -158,7 +163,9 @@ public final class CnvVariantController extends AbstractVariantController {
         genomeBuildComboBox.getItems().addAll(elementValues.getGenomeBuild());
         chromosomeComboBox.getItems().addAll(elementValues.getChromosome());
         beginTextField.setTextFormatter(makeTextFormatter(beginTextField, NON_NEGATIVE_INTEGER_REGEXP));
+        decorateWithTooltipOnFocus(beginTextField, "1-based begin position");
         endTextField.setTextFormatter(makeTextFormatter(endTextField, POSITIVE_INTEGER_REGEXP));
+        decorateWithTooltipOnFocus(endTextField, "1-based end position");
         variantClassComboBox.getItems().addAll(elementValues.getVariantClass());
         genotypeComboBox.getItems().addAll(Arrays.stream(Genotype.values()).filter(g -> !g.equals(Genotype.UNRECOGNIZED)).collect(Collectors.toList()));
         svTypeComboBox.getItems().addAll(Arrays.stream(StructuralType.values()).filter(g -> !g.equals(StructuralType.UNRECOGNIZED)).collect(Collectors.toList()));

--- a/hpo-case-annotator-gui/src/main/resources/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariant.fxml
+++ b/hpo-case-annotator-gui/src/main/resources/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariant.fxml
@@ -1,19 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ComboBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.TitledPane?>
-<?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Font?>
-
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 <TitledPane xmlns="http://javafx.com/javafx/8.0.999-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpo_case_annotator.gui.controllers.variant.CnvVariantController">
    <content>
       <VBox>
@@ -26,6 +16,7 @@
                   <ColumnConstraints halignment="CENTER" minWidth="10.0" />
                   <ColumnConstraints halignment="CENTER" minWidth="10.0" />
                   <ColumnConstraints halignment="CENTER" minWidth="10.0" />
+                  <ColumnConstraints halignment="CENTER"/>
                   <ColumnConstraints halignment="CENTER" />
                   <ColumnConstraints halignment="CENTER" />
                   <ColumnConstraints halignment="CENTER" />
@@ -160,6 +151,12 @@
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </GridPane.margin>
                   </TextField>
+                   <CheckBox fx:id="impreciseCheckBox" mnemonicParsing="false" text="imprecise" GridPane.columnIndex="9"
+                             GridPane.rowIndex="3">
+                       <GridPane.margin>
+                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                       </GridPane.margin>
+                   </CheckBox>
                </children>
             </GridPane>
             <GridPane style="-fx-background-color: #ffcc5c;">

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantControllerTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantControllerTest.java
@@ -93,7 +93,7 @@ public class CnvVariantControllerTest extends ApplicationTest {
                 .setVariantPosition(VariantPosition.newBuilder()
                         .setGenomeAssembly(GenomeAssembly.GRCH_37)
                         .setContig("4")
-                        .setPos(101)
+                        .setPos(100)
                         .setPos2(200)
                         .setRefAllele("N")
                         .setAltAllele("<INS>")

--- a/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantControllerTest.java
+++ b/hpo-case-annotator-gui/src/test/java/org/monarchinitiative/hpo_case_annotator/gui/controllers/variant/CnvVariantControllerTest.java
@@ -83,7 +83,9 @@ public class CnvVariantControllerTest extends ApplicationTest {
                 // ci end second
                 .clickOn("#ciEndSecondTextField").write("20")
                 // cosegregation
-                .clickOn("#cosegregationCheckBox");
+                .clickOn("#cosegregationCheckBox")
+                // imprecise
+                .clickOn("#impreciseCheckBox");
 
         final Variant received = controller.getData();
 
@@ -107,6 +109,7 @@ public class CnvVariantControllerTest extends ApplicationTest {
                         .setContext(VariantValidation.Context.CNV)
                         .setCosegregation(true)
                         .build())
+                .setImprecise(true)
                 .build())));
     }
 

--- a/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/codecs/AbstractDiseaseCaseToPhenopacketCodec.java
+++ b/hpo-case-annotator-model/src/main/java/org/monarchinitiative/hpo_case_annotator/model/codecs/AbstractDiseaseCaseToPhenopacketCodec.java
@@ -197,6 +197,9 @@ public abstract class AbstractDiseaseCaseToPhenopacketCodec implements Codec<Dis
                 String cipos = String.format("CIPOS=%d,%d", vp.getCiBeginOne(), vp.getCiBeginTwo());
                 String ciend = String.format("CIEND=%d,%d", vp.getCiEndOne(), vp.getCiEndTwo());
                 info = String.join(";", svtype, svend, cipos, ciend);
+                if (v.getImprecise()) {
+                    info += ";IMPRECISE";
+                }
             }
             return Variant.newBuilder()
                     .setVcfAllele(VcfAllele.newBuilder()

--- a/hpo-case-annotator-model/src/main/proto/org/monarchinitiative/hpo-case-annotator/model/model.proto
+++ b/hpo-case-annotator-model/src/main/proto/org/monarchinitiative/hpo-case-annotator/model/model.proto
@@ -148,8 +148,11 @@ message Variant {
     // Structural
     StructuralType sv_type = 21;
 
+    // Flag for imprecise CNV variant
+    bool imprecise = 22;
+
     // reserved for CNV fields
-    reserved 22 to 29;
+    reserved 23 to 29;
 
     // Breakpoint fields
     // reserved for Breakpoint fields

--- a/hpo-case-annotator-model/src/test/java/org/monarchinitiative/hpo_case_annotator/model/codecs/DiseaseCaseToPhenopacketCodecTest.java
+++ b/hpo-case-annotator-model/src/test/java/org/monarchinitiative/hpo_case_annotator/model/codecs/DiseaseCaseToPhenopacketCodecTest.java
@@ -210,7 +210,7 @@ public class DiseaseCaseToPhenopacketCodecTest {
                         .setPos(149741531)
                         .setRef("N")
                         .setAlt("<DEL>")
-                        .setInfo("SVTYPE=DEL;END=149744897;CIPOS=-5,5;CIEND=-15,10")
+                        .setInfo("SVTYPE=DEL;END=149744897;CIPOS=-5,5;CIEND=-15,10;IMPRECISE")
                         .build())
                 .setZygosity(AbstractDiseaseCaseToPhenopacketCodec.HET)
                 .build()));

--- a/hpo-case-annotator-model/src/test/java/org/monarchinitiative/hpo_case_annotator/model/test_resources/DiseaseCaseModelExample.java
+++ b/hpo-case-annotator-model/src/test/java/org/monarchinitiative/hpo_case_annotator/model/test_resources/DiseaseCaseModelExample.java
@@ -376,6 +376,7 @@ class DiseaseCaseModelExample {
                         .setVariantValidation(VariantValidation.newBuilder()
                                 .setContext(VariantValidation.Context.CNV)
                                 .build())
+                        .setImprecise(true)
                         .build())
                 /* Family/proband information */
                 .setFamilyInfo(FamilyInfo.newBuilder()


### PR DESCRIPTION
Hi @pnrobinson 
I added the `IMPECISE` flag into the CNV variant view. The flag is added into the `vcfAllele` info field, if it is present.

Please merge if the PR is ok.